### PR TITLE
AllowSelfRedirection Switch

### DIFF
--- a/src/Elf.Tests/ForwardControllerTests.cs
+++ b/src/Elf.Tests/ForwardControllerTests.cs
@@ -228,7 +228,7 @@ namespace Elf.Tests
                 .ReturnsAsync(new SuccessResponse<Link>(null));
 
             _linkVerifierMock
-                .Setup(p => p.Verify(It.IsAny<string>(), It.IsAny<IUrlHelper>(), It.IsAny<HttpRequest>()))
+                .Setup(p => p.Verify(It.IsAny<string>(), It.IsAny<IUrlHelper>(), It.IsAny<HttpRequest>(), false))
                 .Returns(LinkVerifyResult.Valid);
 
             _appSettingsMock.Setup(p => p.Value).Returns(new AppSettings
@@ -270,7 +270,7 @@ namespace Elf.Tests
                 .ReturnsAsync(new SuccessResponse<Link>(null));
 
             _linkVerifierMock
-                .Setup(p => p.Verify(It.IsAny<string>(), It.IsAny<IUrlHelper>(), It.IsAny<HttpRequest>()))
+                .Setup(p => p.Verify(It.IsAny<string>(), It.IsAny<IUrlHelper>(), It.IsAny<HttpRequest>(), false))
                 .Returns(linkVerifyResult);
 
             _appSettingsMock.Setup(p => p.Value).Returns(new AppSettings
@@ -313,7 +313,7 @@ namespace Elf.Tests
                 .ReturnsAsync(new SuccessResponse<Link>(link));
 
             _linkVerifierMock
-                .Setup(p => p.Verify(It.IsAny<string>(), It.IsAny<IUrlHelper>(), It.IsAny<HttpRequest>()))
+                .Setup(p => p.Verify(It.IsAny<string>(), It.IsAny<IUrlHelper>(), It.IsAny<HttpRequest>(), false))
                 .Returns(LinkVerifyResult.Valid);
 
             var ctl = new ForwardController(
@@ -349,7 +349,7 @@ namespace Elf.Tests
                 .ReturnsAsync(new SuccessResponse<Link>(link));
 
             _linkVerifierMock
-                .Setup(p => p.Verify(It.IsAny<string>(), It.IsAny<IUrlHelper>(), It.IsAny<HttpRequest>()))
+                .Setup(p => p.Verify(It.IsAny<string>(), It.IsAny<IUrlHelper>(), It.IsAny<HttpRequest>(), false))
                 .Returns(LinkVerifyResult.Valid);
 
             _appSettingsMock.Setup(p => p.Value).Returns(new AppSettings
@@ -389,7 +389,7 @@ namespace Elf.Tests
                 .ReturnsAsync(new SuccessResponse<Link>(link));
 
             _linkVerifierMock
-                .Setup(p => p.Verify(It.IsAny<string>(), It.IsAny<IUrlHelper>(), It.IsAny<HttpRequest>()))
+                .Setup(p => p.Verify(It.IsAny<string>(), It.IsAny<IUrlHelper>(), It.IsAny<HttpRequest>(), false))
                 .Returns(LinkVerifyResult.InvalidFormat);
 
             var ctl = new ForwardController(

--- a/src/Elf.Tests/LinkVerifierTest.cs
+++ b/src/Elf.Tests/LinkVerifierTest.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Elf.Web;
+using NUnit.Framework;
+
+namespace Elf.Tests
+{
+    [TestFixture]
+    public class LinkVerifierTest
+    {
+        private LinkVerifier _linkVerifier = new LinkVerifier();
+
+        [TestCase("https://go.edi.wang", ExpectedResult = false)]
+        [TestCase("https://go.edi.wang/", ExpectedResult = false)]
+        [TestCase("https://go.edi.wang///", ExpectedResult = false)]
+        [TestCase("https://go.edi.wang/a", ExpectedResult = false)]
+        [TestCase("https://go.edi.wang/a/", ExpectedResult = false)]
+        [TestCase("https://go.edi.wang//a/", ExpectedResult = false)]
+        [TestCase("https://go.edi.wang//a//aka", ExpectedResult = false)]
+        [TestCase("https://go.edi.wang/a//fw", ExpectedResult = false)]
+        [TestCase("https://go.edi.wang/a/fw/b", ExpectedResult = false)]
+        [TestCase("https://go.edi.wang/aka/b", ExpectedResult = true)]
+        [TestCase("https://go.edi.wang/fw/c", ExpectedResult = true)]
+        [TestCase("https://go.edi.wang///fw/c", ExpectedResult = true)]
+        [TestCase("https://go.edi.wang//fw/", ExpectedResult = true)]
+        [TestCase("https://go.edi.wang//fw", ExpectedResult = true)]
+        [TestCase("https://go.edi.wang/fw", ExpectedResult = true)]
+        [TestCase("https://go.edi.wang/aka", ExpectedResult = true)]
+        public bool TestIsForwardEndpoint(string url)
+        {
+            return _linkVerifier.IsForwardEndpoint(new Uri(url));
+        }
+    }
+}

--- a/src/Elf.Web/Controllers/AdminController.cs
+++ b/src/Elf.Web/Controllers/AdminController.cs
@@ -242,7 +242,7 @@ namespace Elf.Web.Controllers
         {
             if (ModelState.IsValid)
             {
-                var verifyResult = _linkVerifier.Verify(model.OriginUrl, Url, Request);
+                var verifyResult = _linkVerifier.Verify(model.OriginUrl, Url, Request, _appSettings.AllowSelfRedirection);
                 switch (verifyResult)
                 {
                     case LinkVerifyResult.InvalidFormat:
@@ -301,7 +301,7 @@ namespace Elf.Web.Controllers
         {
             if (ModelState.IsValid)
             {
-                var verifyResult = _linkVerifier.Verify(model.OriginUrl, Url, Request);
+                var verifyResult = _linkVerifier.Verify(model.OriginUrl, Url, Request, _appSettings.AllowSelfRedirection);
                 switch (verifyResult)
                 {
                     case LinkVerifyResult.InvalidFormat:

--- a/src/Elf.Web/Controllers/ForwardController.cs
+++ b/src/Elf.Web/Controllers/ForwardController.cs
@@ -136,7 +136,7 @@ namespace Elf.Web.Controllers
                         if (string.IsNullOrWhiteSpace(_appSettings.DefaultRedirectionUrl)) return NotFound();
 
                         var verifyDefaultRedirectionUrl =
-                            _linkVerifier.Verify(_appSettings.DefaultRedirectionUrl, Url, Request);
+                            _linkVerifier.Verify(_appSettings.DefaultRedirectionUrl, Url, Request, _appSettings.AllowSelfRedirection);
                         if (verifyDefaultRedirectionUrl == LinkVerifyResult.Valid)
                         {
                             return Redirect(_appSettings.DefaultRedirectionUrl);
@@ -150,7 +150,7 @@ namespace Elf.Web.Controllers
                         return BadRequest("This link is disabled.");
                     }
 
-                    var verifyOriginUrl = _linkVerifier.Verify(link.OriginUrl, Url, Request);
+                    var verifyOriginUrl = _linkVerifier.Verify(link.OriginUrl, Url, Request, _appSettings.AllowSelfRedirection);
                     switch (verifyOriginUrl)
                     {
                         case LinkVerifyResult.Valid:

--- a/src/Elf.Web/LinkVerifier.cs
+++ b/src/Elf.Web/LinkVerifier.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -35,13 +36,37 @@ namespace Elf.Web
             {
                 if (string.Compare(testUri.Authority, currentRequest.Host.ToString(), StringComparison.OrdinalIgnoreCase) == 0
                     && string.Compare(testUri.Scheme, currentRequest.Scheme, StringComparison.OrdinalIgnoreCase) == 0
-                    && testUri.AbsolutePath != "/")
+                    && IsForwardEndpoint(testUri))
                 {
                     return LinkVerifyResult.InvalidSelfReference;
                 }
             }
 
             return LinkVerifyResult.Valid;
+        }
+
+        // Check only for Forward endpoints (fw, aka) as suggested in #10
+        public bool IsForwardEndpoint(Uri uri)
+        {
+            var endpoints = new [] {"fw", "fw/", "aka", "aka/" };
+
+            if (uri.AbsolutePath != "/" && uri.Segments.Length > 1)
+            {
+                
+                for (var i = 1; i < uri.Segments.Length; i++)
+                {
+                    if (uri.Segments[i] == "/") continue;
+
+                    if (endpoints.Any(endpoint =>
+                        string.Compare(uri.Segments[i], endpoint, StringComparison.OrdinalIgnoreCase) == 0))
+                    {
+                        return true;
+                    }
+                    break;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Elf.Web/LinkVerifier.cs
+++ b/src/Elf.Web/LinkVerifier.cs
@@ -14,12 +14,12 @@ namespace Elf.Web
 
     public interface ILinkVerifier
     {
-        LinkVerifyResult Verify(string url, IUrlHelper urlHelper, HttpRequest currentRequest);
+        LinkVerifyResult Verify(string url, IUrlHelper urlHelper, HttpRequest currentRequest, bool allowSelfRedirection = false);
     }
 
     public class LinkVerifier : ILinkVerifier
     {
-        public LinkVerifyResult Verify(string url, IUrlHelper urlHelper, HttpRequest currentRequest)
+        public LinkVerifyResult Verify(string url, IUrlHelper urlHelper, HttpRequest currentRequest, bool allowSelfRedirection = false)
         {
             if (!url.IsValidUrl())
             {
@@ -31,7 +31,7 @@ namespace Elf.Web
                 return LinkVerifyResult.InvalidLocal;
             }
 
-            if (Uri.TryCreate(url, UriKind.Absolute, out var testUri))
+            if (!allowSelfRedirection && Uri.TryCreate(url, UriKind.Absolute, out var testUri))
             {
                 if (string.Compare(testUri.Authority, currentRequest.Host.ToString(), StringComparison.OrdinalIgnoreCase) == 0
                     && string.Compare(testUri.Scheme, currentRequest.Scheme, StringComparison.OrdinalIgnoreCase) == 0

--- a/src/Elf.Web/Models/AppSettings.cs
+++ b/src/Elf.Web/Models/AppSettings.cs
@@ -4,6 +4,8 @@
     {
         public string DefaultRedirectionUrl { get; set; }
 
+        public bool AllowSelfRedirection { get; set; }
+
         public bool HonorDNT { get; set; }
 
         public int TopClientTypes { get; set; }

--- a/src/Elf.Web/appsettings.json
+++ b/src/Elf.Web/appsettings.json
@@ -5,6 +5,7 @@
   "AppSettings": {
     "DefaultRedirectionUrl": "https://edi.wang",
     "HonorDNT": true, 
+    "AllowSelfRedirection": false, 
     "TopClientTypes": 5
   },
   "Authentication": {

--- a/src/ElfCommon.props
+++ b/src/ElfCommon.props
@@ -3,8 +3,8 @@
     <Authors>Edi Wang</Authors>
     <Company>edi.wang</Company>
     <Copyright>(C) 2020 edi.wang@outlook.com</Copyright>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
-    <Version>2.0.0.0</Version>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
+    <Version>2.1.0.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Add settings key ```AllowSelfRedirection``` to allow link that redirects to same URL Authority. Default value is ```false```. Address #10 

To turn on this switch, you can either modify ```appsettings.json``` or set an environment variable to ```true```:

- ```AppSettings:AllowSelfRedirection``` for Windows only
- or ```AppSettings__AllowSelfRedirection``` for Windows, Linux and docker.
