### PR TITLE
Update Admin to .NET 9.0 and bump project version to 6.14.0

### DIFF
--- a/src/Admin/ElfAdmin.csproj
+++ b/src/Admin/ElfAdmin.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Authors>Edi Wang</Authors>
     <Company>edi.wang</Company>
     <Copyright>(C) 2024 edi.wang@outlook.com</Copyright>
-    <Version>6.12.5</Version>
+    <Version>6.14.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.11" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="8.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.10.3" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.10.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.10.4" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.10.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated the target framework from .NET 8.0 to .NET 9.0. Incremented the project version from 6.12.5 to 6.14.0. Updated several package references to newer versions:
- Microsoft.AspNetCore.Components.WebAssembly: 8.0.11 -> 9.0.0
- Microsoft.AspNetCore.Components.WebAssembly.DevServer: 8.0.11 -> 9.0.0
- Microsoft.Authentication.WebAssembly.Msal: 8.0.11 -> 9.0.0
- Microsoft.Extensions.Http: 8.0.1 -> 9.0.0
- Microsoft.FluentUI.AspNetCore.Components: 4.10.3 -> 4.10.4
- Microsoft.FluentUI.AspNetCore.Components.Icons: 4.10.3 -> 4.10.4