### PR TITLE
More LiteBus Migration

### DIFF
--- a/src/API/Controllers/LinkController.cs
+++ b/src/API/Controllers/LinkController.cs
@@ -94,7 +94,7 @@ public class LinkController(
     [ProducesResponseType<PagedLinkResult>(StatusCodes.Status200OK)]
     public async Task<IActionResult> ListByTags(ListByTagsRequest request)
     {
-        var (links, totalRows) = await mediator.Send(new ListByTagsCommand(request));
+        var (links, totalRows) = await mediator.Send(new ListByTagsQuery(request));
 
         var result = new PagedLinkResult
         {

--- a/src/API/Controllers/LinkController.cs
+++ b/src/API/Controllers/LinkController.cs
@@ -58,7 +58,7 @@ public class LinkController(
                 return BadRequest("Can not use url from this site.");
         }
 
-        var token = await mediator.Send(new EditLinkCommand(id, model));
+        var token = await commandMediator.SendAsync(new EditLinkCommand(id, model));
         if (token is not null) await cache.RemoveAsync(token);
         return NoContent();
     }

--- a/src/API/Controllers/LinkController.cs
+++ b/src/API/Controllers/LinkController.cs
@@ -125,7 +125,7 @@ public class LinkController(
         var link = await queryMediator.QueryAsync(new GetLinkQuery(id));
         if (link is null) return NotFound();
 
-        await mediator.Send(new DeleteLinkCommand(id));
+        await commandMediator.SendAsync(new DeleteLinkCommand(id));
 
         await cache.RemoveAsync(link.FwToken);
         return Ok();

--- a/src/API/Controllers/TagController.cs
+++ b/src/API/Controllers/TagController.cs
@@ -46,7 +46,7 @@ public class TagController(IMediator mediator, ICommandMediator commandMediator,
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Delete(int id)
     {
-        var code = await mediator.Send(new DeleteTagCommand(id));
+        var code = await commandMediator.SendAsync(new DeleteTagCommand(id));
         if (code == -1) return NotFound();
 
         return NoContent();

--- a/src/API/Features/DeleteLinkCommand.cs
+++ b/src/API/Features/DeleteLinkCommand.cs
@@ -1,12 +1,13 @@
 ﻿using Elf.Api.Data;
+using LiteBus.Commands.Abstractions;
 
 namespace Elf.Api.Features;
 
-public record DeleteLinkCommand(int Id) : IRequest;
+public record DeleteLinkCommand(int Id) : ICommand;
 
-public class DeleteLinkCommandHandler(ElfDbContext dbContext) : IRequestHandler<DeleteLinkCommand>
+public class DeleteLinkCommandHandler(ElfDbContext dbContext) : ICommandHandler<DeleteLinkCommand>
 {
-    public async Task Handle(DeleteLinkCommand request, CancellationToken ct)
+    public async Task HandleAsync(DeleteLinkCommand request, CancellationToken ct)
     {
         var link = await dbContext.Link.FindAsync(request.Id);
         if (link != null)

--- a/src/API/Features/DeleteTagCommand.cs
+++ b/src/API/Features/DeleteTagCommand.cs
@@ -1,12 +1,13 @@
 ﻿using Elf.Api.Data;
+using LiteBus.Commands.Abstractions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Elf.Api.Features;
 
-public record DeleteTagCommand(int Id) : IRequest<int>;
+public record DeleteTagCommand(int Id) : ICommand<int>;
 
-public class DeleteTagCommandHandler(ElfDbContext dbContext) : IRequestHandler<DeleteTagCommand, int>
+public class DeleteTagCommandHandler(ElfDbContext dbContext) : ICommandHandler<DeleteTagCommand, int>
 {
-    public async Task<int> Handle(DeleteTagCommand request, CancellationToken ct) =>
+    public async Task<int> HandleAsync(DeleteTagCommand request, CancellationToken ct) =>
          await dbContext.Tag.Where(p => p.Id == request.Id).ExecuteDeleteAsync(cancellationToken: ct) == 0 ? -1 : 0;
 }

--- a/src/API/Features/EditLinkCommand.cs
+++ b/src/API/Features/EditLinkCommand.cs
@@ -1,14 +1,15 @@
 ﻿using Elf.Api.Data;
 using Elf.Shared;
+using LiteBus.Commands.Abstractions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Elf.Api.Features;
 
-public record EditLinkCommand(int Id, LinkEditModel Payload) : IRequest<string>;
+public record EditLinkCommand(int Id, LinkEditModel Payload) : ICommand<string>;
 
-public class EditLinkCommandHandler(ElfDbContext dbContext) : IRequestHandler<EditLinkCommand, string>
+public class EditLinkCommandHandler(ElfDbContext dbContext) : ICommandHandler<EditLinkCommand, string>
 {
-    public async Task<string> Handle(EditLinkCommand request, CancellationToken ct)
+    public async Task<string> HandleAsync(EditLinkCommand request, CancellationToken ct)
     {
         var (id, payload) = request;
 

--- a/src/API/Features/ListByTagsQuery.cs
+++ b/src/API/Features/ListByTagsQuery.cs
@@ -4,11 +4,11 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Elf.Api.Features;
 
-public record ListByTagsCommand(ListByTagsRequest Payload) : IRequest<(List<LinkModel> Links, int TotalRows)>;
+public record ListByTagsQuery(ListByTagsRequest Payload) : IRequest<(List<LinkModel> Links, int TotalRows)>;
 
-public class ListByTagsCommandHandler(ElfDbContext dbContext) : IRequestHandler<ListByTagsCommand, (List<LinkModel> Links, int TotalRows)>
+public class ListByTagsQueryHandler(ElfDbContext dbContext) : IRequestHandler<ListByTagsQuery, (List<LinkModel> Links, int TotalRows)>
 {
-    public async Task<(List<LinkModel> Links, int TotalRows)> Handle(ListByTagsCommand request, CancellationToken ct)
+    public async Task<(List<LinkModel> Links, int TotalRows)> Handle(ListByTagsQuery request, CancellationToken ct)
     {
         var query = from l in dbContext.Link.Include(l => l.Tags)
                     where l.Tags.Any(t => request.Payload.TagIds.Contains(t.Id))


### PR DESCRIPTION
This pull request refactors the mediator pattern implementation in the API controllers and feature handlers by transitioning from `IRequest` to `ICommand` and `IQuery` interfaces provided by LiteBus. Additionally, it improves consistency in naming conventions and updates method signatures to align with the new interfaces.

### Changes to mediator pattern implementation:

* **Controller updates**:
  - Replaced `mediator.Send` with `commandMediator.SendAsync` in `Edit`, `Delete`, and `Update` actions in `LinkController` and `TagController` to use the LiteBus `ICommand` interface. (`src/API/Controllers/LinkController.cs`: [[1]](diffhunk://#diff-32f11b52ed774bfde3a5ac391386d6d48bfe467ae6849db1a0776a03cd45e893L61-R61) [[2]](diffhunk://#diff-32f11b52ed774bfde3a5ac391386d6d48bfe467ae6849db1a0776a03cd45e893L128-R128); `src/API/Controllers/TagController.cs`: [[3]](diffhunk://#diff-291968bb74376bd501776e3356b99cdc61047464e2d584e0056b3986262af4e7L49-R49)
  - Updated `ListByTags` action in `LinkController` to use `ListByTagsQuery` instead of `ListByTagsCommand`, reflecting the transition to LiteBus `IQuery` interface. (`src/API/Controllers/LinkController.cs`: [src/API/Controllers/LinkController.csL97-R97](diffhunk://#diff-32f11b52ed774bfde3a5ac391386d6d48bfe467ae6849db1a0776a03cd45e893L97-R97))

* **Feature handler updates**:
  - Changed `DeleteLinkCommand`, `DeleteTagCommand`, and `EditLinkCommand` from `IRequest` to `ICommand`, and updated their handlers to implement `ICommandHandler` instead of `IRequestHandler`. (`src/API/Features/DeleteLinkCommand.cs`: [[1]](diffhunk://#diff-f3fac5db1ba920161816a4209512ff13063667f76e72261b00e3bcf6f8439e1fR2-R10) `src/API/Features/DeleteTagCommand.cs`: [[2]](diffhunk://#diff-9d0b5fe947aab0d7e8966b431734a943164abc97e7ff0a33fb9b0751a684cc70R2-R11) `src/API/Features/EditLinkCommand.cs`: [[3]](diffhunk://#diff-7672ef6de6a01b017ad7d4bfd0c80ebd5b499ee96794d28e2fb05789dd60202bR3-R12)
  - Renamed `ListByTagsCommand` to `ListByTagsQuery` and updated its handler to reflect the use of the `IQuery` interface. (`src/API/Features/ListByTagsQuery.cs`: [src/API/Features/ListByTagsQuery.csL7-R11](diffhunk://#diff-e40a39ac1a7f88a1efd88dfe2a934e3f81ce7b2709f36f7de978cf87b4c24c30L7-R11))

### Method signature updates:

* Updated `Handle` methods in feature handlers to `HandleAsync` to align with LiteBus conventions for asynchronous handling. (`src/API/Features/DeleteLinkCommand.cs`: [[1]](diffhunk://#diff-f3fac5db1ba920161816a4209512ff13063667f76e72261b00e3bcf6f8439e1fR2-R10) `src/API/Features/DeleteTagCommand.cs`: [[2]](diffhunk://#diff-9d0b5fe947aab0d7e8966b431734a943164abc97e7ff0a33fb9b0751a684cc70R2-R11) `src/API/Features/EditLinkCommand.cs`: [[3]](diffhunk://#diff-7672ef6de6a01b017ad7d4bfd0c80ebd5b499ee96794d28e2fb05789dd60202bR3-R12)