### PR TITLE
Add status toggle for links in admin UI

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,8 +3,8 @@
     <Authors>Edi Wang</Authors>
     <Company>edi.wang</Company>
     <Copyright>(C) 2025 edi.wang@outlook.com</Copyright>
-    <AssemblyVersion>7.0.0</AssemblyVersion>
-    <FileVersion>7.0.0</FileVersion>
-    <Version>7.0.0</Version>
+    <AssemblyVersion>7.1.0</AssemblyVersion>
+    <FileVersion>7.1.0</FileVersion>
+    <Version>7.1.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Replaces the status badge with a switch to enable or disable links directly from the admin interface. Integrates setLinkEnabled API call and handles UI updates and error feedback for status changes.