### PR TITLE
Add ForwarderBaseUrl app setting to admin app

### DIFF
--- a/deployment/main.bicep
+++ b/deployment/main.bicep
@@ -160,6 +160,14 @@ resource adminConnectionString 'Microsoft.Web/sites/config@2022-09-01' = {
   }
 }
 
+resource adminForwarderBaseUrl 'Microsoft.Web/sites/config@2022-09-01' = {
+  parent: adminApp
+  name: 'appsettings'
+  properties: {
+    ForwarderBaseUrl: 'https://${forwarderApp.properties.defaultHostName}'
+  }
+}
+
 output forwarderAppUrl string = forwarderApp.properties.defaultHostName
 output adminAppUrl string = adminApp.properties.defaultHostName
 output sqlServerName string = sqlServer.name


### PR DESCRIPTION
Introduces a new app setting 'ForwarderBaseUrl' to the admin app configuration, referencing the forwarder app's default host name. This enables the admin app to dynamically access the forwarder base URL.